### PR TITLE
refactor: rename build script and add build:domain

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -86,7 +86,7 @@
         "testStrategy": "TDD cycle: Red-Green-Refactor. Test all validation rules, edge cases with Unicode, boundary conditions, and error message accuracy",
         "priority": "high",
         "dependencies": [7],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": []
       },
       {
@@ -499,7 +499,7 @@
     ],
     "metadata": {
       "created": "2025-09-01T19:04:18.307Z",
-      "updated": "2025-09-03T12:26:05.429Z",
+      "updated": "2025-09-03T12:36:08.226Z",
       "description": "Tasks for master context with TDD approach enforced throughout development as per PRD requirements"
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "packageManager": "yarn@3.6.4",
   "scripts": {
-    "build": "yarn workspace @misc-poc/shared build",
+    "build:shared": "yarn workspace @misc-poc/shared build",
+    "build:domain": "yarn workspace @misc-poc/domain build",
     "test": "yarn test:all",
     "test:shared": "yarn workspace @misc-poc/shared test",
     "test:domain": "yarn workspace @misc-poc/domain test",


### PR DESCRIPTION
- Rename `build` to `build:shared` for consistency with test patterns
- Add `build:domain` script to match existing `test:domain` pattern