### PR TITLE
Task #15: Implement RecordDuplicateChecker Domain Service (TDD)

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -163,7 +163,7 @@
         "testStrategy": "TDD cycle: Write failing tests → Implement → Refactor. Test duplicate detection with various tag combinations, set equality edge cases, and exclusion logic",
         "priority": "high",
         "dependencies": [12],
-        "status": "pending",
+        "status": "in-progress",
         "subtasks": []
       },
       {
@@ -499,7 +499,7 @@
     ],
     "metadata": {
       "created": "2025-09-01T19:04:18.307Z",
-      "updated": "2025-09-03T14:10:44.332Z",
+      "updated": "2025-09-03T14:27:01.732Z",
       "description": "Tasks for master context with TDD approach enforced throughout development as per PRD requirements"
     }
   }

--- a/packages/domain/src/__tests__/record-duplicate-checker.test.ts
+++ b/packages/domain/src/__tests__/record-duplicate-checker.test.ts
@@ -1,0 +1,440 @@
+import { RecordDuplicateChecker } from '../record-duplicate-checker';
+import { Record } from '../record';
+import { RecordId, RecordContent, TagId } from '@misc-poc/shared';
+
+describe('RecordDuplicateChecker Domain Service', () => {
+  const tagId1 = TagId.generate();
+  const tagId2 = TagId.generate();
+  const tagId3 = TagId.generate();
+  const baseDate = new Date('2023-01-01T00:00:00.000Z');
+
+  describe('isDuplicate', () => {
+    let duplicateChecker: RecordDuplicateChecker;
+
+    beforeEach(() => {
+      duplicateChecker = new RecordDuplicateChecker();
+    });
+
+    it('should return true when two records have identical tag sets', () => {
+      const tagIds = new Set([tagId1, tagId2]);
+      const record1 = new Record(
+        RecordId.generate(),
+        new RecordContent('first content'),
+        tagIds,
+        baseDate,
+        baseDate
+      );
+      const record2 = new Record(
+        RecordId.generate(),
+        new RecordContent('second content'),
+        tagIds,
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(record1, record2)).toBe(true);
+    });
+
+    it('should return true when tag sets contain same tags in different order', () => {
+      const tagIds1 = new Set([tagId1, tagId2]);
+      const tagIds2 = new Set([tagId2, tagId1]); // Same tags, different insertion order
+
+      const record1 = new Record(
+        RecordId.generate(),
+        new RecordContent('first content'),
+        tagIds1,
+        baseDate,
+        baseDate
+      );
+      const record2 = new Record(
+        RecordId.generate(),
+        new RecordContent('second content'),
+        tagIds2,
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(record1, record2)).toBe(true);
+    });
+
+    it('should return false when records have different tag sets', () => {
+      const tagIds1 = new Set([tagId1, tagId2]);
+      const tagIds2 = new Set([tagId1, tagId3]); // Different second tag
+
+      const record1 = new Record(
+        RecordId.generate(),
+        new RecordContent('first content'),
+        tagIds1,
+        baseDate,
+        baseDate
+      );
+      const record2 = new Record(
+        RecordId.generate(),
+        new RecordContent('second content'),
+        tagIds2,
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(record1, record2)).toBe(false);
+    });
+
+    it('should return false when one record has empty tag set and other has tags', () => {
+      const emptyTagIds = new Set<TagId>();
+      const nonEmptyTagIds = new Set([tagId1]);
+
+      const emptyRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('empty tags content'),
+        emptyTagIds,
+        baseDate,
+        baseDate
+      );
+      const nonEmptyRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('non-empty tags content'),
+        nonEmptyTagIds,
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(emptyRecord, nonEmptyRecord)).toBe(
+        false
+      );
+      expect(duplicateChecker.isDuplicate(nonEmptyRecord, emptyRecord)).toBe(
+        false
+      );
+    });
+
+    it('should return true when both records have empty tag sets', () => {
+      const emptyTagIds1 = new Set<TagId>();
+      const emptyTagIds2 = new Set<TagId>();
+
+      const record1 = new Record(
+        RecordId.generate(),
+        new RecordContent('first empty content'),
+        emptyTagIds1,
+        baseDate,
+        baseDate
+      );
+      const record2 = new Record(
+        RecordId.generate(),
+        new RecordContent('second empty content'),
+        emptyTagIds2,
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(record1, record2)).toBe(true);
+    });
+
+    it('should return false when records have tag sets of different sizes', () => {
+      const singleTagIds = new Set([tagId1]);
+      const doubleTagIds = new Set([tagId1, tagId2]);
+
+      const singleTagRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('single tag content'),
+        singleTagIds,
+        baseDate,
+        baseDate
+      );
+      const doubleTagRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('double tag content'),
+        doubleTagIds,
+        baseDate,
+        baseDate
+      );
+
+      expect(
+        duplicateChecker.isDuplicate(singleTagRecord, doubleTagRecord)
+      ).toBe(false);
+    });
+
+    it('should handle null record1 gracefully', () => {
+      const record = new Record(
+        RecordId.generate(),
+        new RecordContent('test content'),
+        new Set([tagId1]),
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(null as any, record)).toBe(false);
+    });
+
+    it('should handle null record2 gracefully', () => {
+      const record = new Record(
+        RecordId.generate(),
+        new RecordContent('test content'),
+        new Set([tagId1]),
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(record, null as any)).toBe(false);
+    });
+
+    it('should handle both records being null', () => {
+      expect(duplicateChecker.isDuplicate(null as any, null as any)).toBe(
+        false
+      );
+    });
+
+    it('should handle undefined records gracefully', () => {
+      const record = new Record(
+        RecordId.generate(),
+        new RecordContent('test content'),
+        new Set([tagId1]),
+        baseDate,
+        baseDate
+      );
+
+      expect(duplicateChecker.isDuplicate(undefined as any, record)).toBe(
+        false
+      );
+      expect(duplicateChecker.isDuplicate(record, undefined as any)).toBe(
+        false
+      );
+      expect(
+        duplicateChecker.isDuplicate(undefined as any, undefined as any)
+      ).toBe(false);
+    });
+  });
+
+  describe('findDuplicatesIn', () => {
+    let duplicateChecker: RecordDuplicateChecker;
+
+    beforeEach(() => {
+      duplicateChecker = new RecordDuplicateChecker();
+    });
+
+    it('should return empty array when no duplicates exist', () => {
+      const tagIds1 = new Set([tagId1]);
+      const tagIds2 = new Set([tagId2]);
+      const tagIds3 = new Set([tagId3]);
+
+      const record1 = new Record(
+        RecordId.generate(),
+        new RecordContent('content1'),
+        tagIds1,
+        baseDate,
+        baseDate
+      );
+      const record2 = new Record(
+        RecordId.generate(),
+        new RecordContent('content2'),
+        tagIds2,
+        baseDate,
+        baseDate
+      );
+      const record3 = new Record(
+        RecordId.generate(),
+        new RecordContent('content3'),
+        tagIds3,
+        baseDate,
+        baseDate
+      );
+
+      const targetRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('target'),
+        new Set([tagId1, tagId2]),
+        baseDate,
+        baseDate
+      );
+      const records = [record1, record2, record3];
+
+      expect(duplicateChecker.findDuplicatesIn(targetRecord, records)).toEqual(
+        []
+      );
+    });
+
+    it('should return records that are duplicates of target record', () => {
+      const sharedTagIds = new Set([tagId1, tagId2]);
+      const differentTagIds = new Set([tagId3]);
+
+      const targetRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('target'),
+        sharedTagIds,
+        baseDate,
+        baseDate
+      );
+      const duplicate1 = new Record(
+        RecordId.generate(),
+        new RecordContent('dup1'),
+        sharedTagIds,
+        baseDate,
+        baseDate
+      );
+      const duplicate2 = new Record(
+        RecordId.generate(),
+        new RecordContent('dup2'),
+        sharedTagIds,
+        baseDate,
+        baseDate
+      );
+      const nonDuplicate = new Record(
+        RecordId.generate(),
+        new RecordContent('different'),
+        differentTagIds,
+        baseDate,
+        baseDate
+      );
+
+      const records = [duplicate1, nonDuplicate, duplicate2];
+
+      const result = duplicateChecker.findDuplicatesIn(targetRecord, records);
+
+      expect(result).toHaveLength(2);
+      expect(result).toContain(duplicate1);
+      expect(result).toContain(duplicate2);
+      expect(result).not.toContain(nonDuplicate);
+    });
+
+    it('should exclude target record itself from results when present in collection', () => {
+      const sharedTagIds = new Set([tagId1, tagId2]);
+
+      const targetRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('target'),
+        sharedTagIds,
+        baseDate,
+        baseDate
+      );
+      const duplicate = new Record(
+        RecordId.generate(),
+        new RecordContent('duplicate'),
+        sharedTagIds,
+        baseDate,
+        baseDate
+      );
+      const nonDuplicate = new Record(
+        RecordId.generate(),
+        new RecordContent('different'),
+        new Set([tagId3]),
+        baseDate,
+        baseDate
+      );
+
+      const records = [targetRecord, duplicate, nonDuplicate]; // Target record included in collection
+
+      const result = duplicateChecker.findDuplicatesIn(targetRecord, records);
+
+      expect(result).toHaveLength(1);
+      expect(result).toContain(duplicate);
+      expect(result).not.toContain(targetRecord); // Should not include itself
+      expect(result).not.toContain(nonDuplicate);
+    });
+
+    it('should handle empty records collection', () => {
+      const targetRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('target'),
+        new Set([tagId1]),
+        baseDate,
+        baseDate
+      );
+      const records: Record[] = [];
+
+      expect(duplicateChecker.findDuplicatesIn(targetRecord, records)).toEqual(
+        []
+      );
+    });
+
+    it('should handle null target record', () => {
+      const records = [
+        new Record(
+          RecordId.generate(),
+          new RecordContent('content'),
+          new Set([tagId1]),
+          baseDate,
+          baseDate
+        ),
+      ];
+
+      expect(duplicateChecker.findDuplicatesIn(null as any, records)).toEqual(
+        []
+      );
+    });
+
+    it('should handle null records collection', () => {
+      const targetRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('target'),
+        new Set([tagId1]),
+        baseDate,
+        baseDate
+      );
+
+      expect(
+        duplicateChecker.findDuplicatesIn(targetRecord, null as any)
+      ).toEqual([]);
+    });
+
+    it('should handle records collection with null entries', () => {
+      const sharedTagIds = new Set([tagId1, tagId2]);
+
+      const targetRecord = new Record(
+        RecordId.generate(),
+        new RecordContent('target'),
+        sharedTagIds,
+        baseDate,
+        baseDate
+      );
+      const duplicate = new Record(
+        RecordId.generate(),
+        new RecordContent('duplicate'),
+        sharedTagIds,
+        baseDate,
+        baseDate
+      );
+
+      const records = [null, duplicate, null] as any;
+
+      const result = duplicateChecker.findDuplicatesIn(targetRecord, records);
+
+      expect(result).toHaveLength(1);
+      expect(result).toContain(duplicate);
+    });
+  });
+
+  describe('performance with large tag sets', () => {
+    let duplicateChecker: RecordDuplicateChecker;
+
+    beforeEach(() => {
+      duplicateChecker = new RecordDuplicateChecker();
+    });
+
+    it('should efficiently handle records with many tags', () => {
+      // Create two records with 100 identical tags
+      const manyTags = new Set(
+        Array.from({ length: 100 }, () => TagId.generate())
+      );
+
+      const record1 = new Record(
+        RecordId.generate(),
+        new RecordContent('first content'),
+        manyTags,
+        baseDate,
+        baseDate
+      );
+      const record2 = new Record(
+        RecordId.generate(),
+        new RecordContent('second content'),
+        manyTags,
+        baseDate,
+        baseDate
+      );
+
+      const startTime = Date.now();
+      const result = duplicateChecker.isDuplicate(record1, record2);
+      const endTime = Date.now();
+
+      expect(result).toBe(true);
+      expect(endTime - startTime).toBeLessThan(100); // Should complete in under 100ms
+    });
+  });
+});

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -6,3 +6,4 @@ export { TagParser } from './tag-parser';
 export { Tag } from './tag';
 export { TagFactory } from './tag-factory';
 export { Record } from './record';
+export { RecordDuplicateChecker } from './record-duplicate-checker';

--- a/packages/domain/src/record-duplicate-checker.ts
+++ b/packages/domain/src/record-duplicate-checker.ts
@@ -1,0 +1,44 @@
+import { Record } from './record';
+
+export class RecordDuplicateChecker {
+  isDuplicate(record1: Record, record2: Record): boolean {
+    if (!record1 || !record2) {
+      return false;
+    }
+
+    if (!(record1 instanceof Record) || !(record2 instanceof Record)) {
+      return false;
+    }
+
+    return record1.hasSameTagSet(record2);
+  }
+
+  findDuplicatesIn(targetRecord: Record, records: Record[]): Record[] {
+    if (!targetRecord || !(targetRecord instanceof Record)) {
+      return [];
+    }
+
+    if (!records || !Array.isArray(records)) {
+      return [];
+    }
+
+    const duplicates: Record[] = [];
+
+    for (const record of records) {
+      if (!record || !(record instanceof Record)) {
+        continue; // Skip null/undefined/invalid entries
+      }
+
+      // Exclude the target record itself from results
+      if (targetRecord.equals(record)) {
+        continue;
+      }
+
+      if (this.isDuplicate(targetRecord, record)) {
+        duplicates.push(record);
+      }
+    }
+
+    return duplicates;
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented RecordDuplicateChecker service to detect duplicate records based on tag sets using TDD approach
- Added isDuplicate() method for comparing two records by tag sets (order independent)
- Added findDuplicatesIn() method for finding duplicates in collections with exclusion logic
- Used comprehensive TDD with 18 test cases covering all edge cases

## Test plan
- [x] All tests pass (18/18) with comprehensive edge case coverage
- [x] TypeScript compilation passes without errors  
- [x] Pre-commit hooks pass (linting, formatting, testing)
- [x] Service properly exported from domain package
- [x] Leverages existing Record.hasSameTagSet() for efficient comparison
- [x] Handles null/undefined records gracefully
- [x] Excludes target record from duplicate search results
- [x] Performance tested with large tag sets