### PR TITLE
fix: remove unused TagRepository parameter from SearchRecordsUseCase

### DIFF
--- a/packages/application/src/use-cases/__tests__/search-records-use-case.test.ts
+++ b/packages/application/src/use-cases/__tests__/search-records-use-case.test.ts
@@ -315,29 +315,20 @@ describe('SearchRecordsUseCase', () => {
     mockRecordRepository = new MockRecordRepository();
     mockTagRepository = new MockTagRepository();
     mockRecordRepository.setTagRepository(mockTagRepository);
-    useCase = new SearchRecordsUseCase(mockRecordRepository, mockTagRepository);
+    useCase = new SearchRecordsUseCase(mockRecordRepository);
   });
 
   describe('constructor', () => {
     it('should throw error when RecordRepository is null or undefined', () => {
-      expect(
-        () => new SearchRecordsUseCase(null as any, mockTagRepository)
-      ).toThrow('RecordRepository cannot be null or undefined');
-      expect(
-        () => new SearchRecordsUseCase(undefined as any, mockTagRepository)
-      ).toThrow('RecordRepository cannot be null or undefined');
+      expect(() => new SearchRecordsUseCase(null as any)).toThrow(
+        'RecordRepository cannot be null or undefined'
+      );
+      expect(() => new SearchRecordsUseCase(undefined as any)).toThrow(
+        'RecordRepository cannot be null or undefined'
+      );
     });
 
-    it('should throw error when TagRepository is null or undefined', () => {
-      expect(
-        () => new SearchRecordsUseCase(mockRecordRepository, null as any)
-      ).toThrow('TagRepository cannot be null or undefined');
-      expect(
-        () => new SearchRecordsUseCase(mockRecordRepository, undefined as any)
-      ).toThrow('TagRepository cannot be null or undefined');
-    });
-
-    it('should create instance successfully with valid repositories', () => {
+    it('should create instance successfully with valid repository', () => {
       expect(useCase).toBeInstanceOf(SearchRecordsUseCase);
     });
   });
@@ -668,10 +659,7 @@ describe('SearchRecordsUseCase', () => {
           ),
       };
 
-      const useCaseWithError = new SearchRecordsUseCase(
-        errorRepository as any,
-        mockTagRepository
-      );
+      const useCaseWithError = new SearchRecordsUseCase(errorRepository as any);
       const request: SearchRecordsRequest = { query: 'test' };
 
       const result = await useCaseWithError.execute(request);
@@ -693,10 +681,7 @@ describe('SearchRecordsUseCase', () => {
           ),
       };
 
-      const useCaseWithError = new SearchRecordsUseCase(
-        errorRepository as any,
-        mockTagRepository
-      );
+      const useCaseWithError = new SearchRecordsUseCase(errorRepository as any);
       const request: SearchRecordsRequest = { query: '' };
 
       const result = await useCaseWithError.execute(request);
@@ -726,10 +711,7 @@ describe('SearchRecordsUseCase', () => {
         search: jest.fn().mockRejectedValue(new Error('Unexpected error')),
       };
 
-      const useCaseWithError = new SearchRecordsUseCase(
-        errorRepository as any,
-        mockTagRepository
-      );
+      const useCaseWithError = new SearchRecordsUseCase(errorRepository as any);
       const request: SearchRecordsRequest = { query: 'test' };
 
       const result = await useCaseWithError.execute(request);

--- a/packages/application/src/use-cases/search-records-use-case.ts
+++ b/packages/application/src/use-cases/search-records-use-case.ts
@@ -4,7 +4,6 @@ import {
   RecordRepository,
   RecordSearchOptions,
 } from '../ports/record-repository';
-import { TagRepository } from '../ports/tag-repository';
 import {
   SearchResultDTO,
   SearchResultDTOMapper,
@@ -21,21 +20,13 @@ export interface SearchRecordsResponse {
 
 export class SearchRecordsUseCase {
   private readonly recordRepository: RecordRepository;
-  private readonly tagRepository: TagRepository;
 
-  constructor(
-    recordRepository: RecordRepository,
-    tagRepository: TagRepository
-  ) {
+  constructor(recordRepository: RecordRepository) {
     if (recordRepository == null) {
       throw new Error('RecordRepository cannot be null or undefined');
     }
-    if (tagRepository == null) {
-      throw new Error('TagRepository cannot be null or undefined');
-    }
 
     this.recordRepository = recordRepository;
-    this.tagRepository = tagRepository;
   }
 
   async execute(


### PR DESCRIPTION
- Removed unused TagRepository dependency injection
- Updated tests to match the simplified constructor
- All 167 tests still pass with proper functionality
- Addresses TypeScript warning about unused parameter