### PR TITLE
Hotfix: TypeScript errors in ExportData use case

### DIFF
--- a/packages/application/src/use-cases/export-data-use-case.ts
+++ b/packages/application/src/use-cases/export-data-use-case.ts
@@ -52,17 +52,17 @@ export class ExportDataUseCase {
       // Fetch all records
       const recordsResult = await this.recordRepository.findAll();
       if (recordsResult.isErr()) {
-        return Err(recordsResult.error);
+        return Err(recordsResult.unwrapErr());
       }
 
       // Fetch all tags for reference (though we'll remove UUIDs)
       const tagsResult = await this.tagRepository.findAll();
       if (tagsResult.isErr()) {
-        return Err(tagsResult.error);
+        return Err(tagsResult.unwrapErr());
       }
 
-      const records = recordsResult.value.records;
-      const tags = tagsResult.value;
+      const records = recordsResult.unwrap().records;
+      const tags = tagsResult.unwrap();
 
       // Create mapping from tag IDs to normalized values for portable export
       const tagIdToNormalizedValue = new Map<string, string>();


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation errors in the ExportData use case that were introduced in PR #34.

## Changes
- Fix Result type access by using `.unwrapErr()` instead of `.error`
- Fix Result type access by using `.unwrap()` instead of `.value`

## Test Results
- ✅ All 18 ExportData use case tests pass
- ✅ TypeScript compilation successful
- ✅ All linting and formatting checks pass

## Root Cause
The original implementation used incorrect Result type access patterns that bypassed TypeScript's type safety. This hotfix ensures proper usage of the Result API.