### PR TITLE
feat: add working web development commands and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ nvm use
 # Установить зависимости
 yarn install
 
-# Запустить разработку
+# Запустить веб-приложение
 yarn dev
 ```
 
@@ -41,6 +41,28 @@ yarn build:incremental
 # Очистка основного пакета
 yarn clean
 ```
+
+### Веб-приложение
+
+```bash
+# Запустить веб-приложение (сборка + preview сервер)
+yarn dev
+# или альтернативная команда
+yarn web:start
+
+# Приложение будет доступно на http://localhost:4173/
+
+# Только сборка веб-приложения
+yarn workspace @misc-poc/presentation-web build
+
+# Только preview сервер (после сборки)
+yarn workspace @misc-poc/presentation-web preview
+
+# Тестирование веб-приложения
+yarn workspace @misc-poc/presentation-web test
+```
+
+**Примечание**: Development сервер на порту 3000 недоступен из-за проблем совместимости Node.js v22 с Yarn PnP. Используется production preview сервер на порту 4173, который предоставляет ту же функциональность.
 
 ### Тестирование
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "packageManager": "yarn@3.6.4",
   "scripts": {
     "test": "yarn workspace @misc-poc/shared test; yarn workspace @misc-poc/domain test; yarn workspace @misc-poc/application test --passWithNoTests; yarn workspace @misc-poc/infrastructure-localstorage test --passWithNoTests; yarn workspace @misc-poc/presentation-cli test --passWithNoTests; yarn workspace @misc-poc/presentation-web test --passWithNoTests",
-    "dev": "yarn workspace @misc-poc/presentation-web dev",
+    "dev": "yarn workspace @misc-poc/presentation-web build && yarn workspace @misc-poc/presentation-web preview",
+    "web:start": "yarn workspace @misc-poc/presentation-web build && yarn workspace @misc-poc/presentation-web preview",
     "clean": "yarn workspace @misc-poc/shared clean; yarn workspace @misc-poc/domain clean; yarn workspace @misc-poc/application clean; yarn workspace @misc-poc/infrastructure-localstorage clean; yarn workspace @misc-poc/presentation-cli clean; yarn workspace @misc-poc/presentation-web clean",
     "all": "echo 'Use: yarn test, yarn lint, yarn typecheck, yarn build, or yarn clean'",
     "lint": "yarn exec eslint packages/shared/src --ext .ts; yarn exec eslint packages/domain/src --ext .ts; yarn exec eslint packages/application/src --ext .ts; yarn exec eslint packages/infrastructure/localStorage/src --ext .ts; echo 'CLI: No src directory found, skipping lint'; yarn exec eslint packages/presentation/web/src --ext .ts,.tsx",


### PR DESCRIPTION
- Update yarn dev script to use build + preview instead of broken dev server
- Add yarn web:start as alternative command for starting web application
- Add comprehensive web development section to README with usage instructions
- Document Node.js v22 + Yarn PnP compatibility issue and preview server solution
- Web app now accessible at http://localhost:4173/ with reliable serving