### PR TITLE
fix: resolve critical CreateRecordUseCase transaction bug and elimina…

### DIFF
--- a/packages/application/src/use-cases/__tests__/create-record-use-case.test.ts
+++ b/packages/application/src/use-cases/__tests__/create-record-use-case.test.ts
@@ -63,6 +63,11 @@ describe('CreateRecordUseCase', () => {
       begin: jest.fn(),
       commit: jest.fn(),
       rollback: jest.fn().mockResolvedValue(Ok(undefined)),
+      execute: jest.fn(),
+      isActive: jest.fn(),
+      dispose: jest.fn(),
+      records: mockRecordRepository,
+      tags: mockTagRepository,
     };
 
     mockTagParser = {
@@ -328,6 +333,8 @@ describe('CreateRecordUseCase', () => {
         mockTagFactory.createFromString.mockReturnValue(newTag);
 
         mockTagRepository.findByNormalizedValue.mockResolvedValue(Ok(null));
+        mockRecordRepository.findByTagSet.mockResolvedValue(Ok([]));
+        mockUnitOfWork.begin.mockResolvedValue(Ok(undefined));
         mockTagRepository.save.mockResolvedValue(
           Err(new DomainError('REPOSITORY_ERROR', 'Tag creation failed'))
         );

--- a/packages/presentation/web/src/components/__tests__/ImportExport.test.tsx
+++ b/packages/presentation/web/src/components/__tests__/ImportExport.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ImportExport } from '../ImportExport'
 import { Ok, Err } from '@misc-poc/shared'
@@ -399,10 +399,12 @@ describe('ImportExport Component', () => {
       render(<ImportExport />)
 
       const fileInput = screen.getByLabelText(/select file/i)
-      fireEvent.change(fileInput, { target: { files: [mockFile] } })
-
       const importButton = screen.getByRole('button', { name: /import/i })
-      fireEvent.click(importButton)
+
+      await act(async () => {
+        fireEvent.change(fileInput, { target: { files: [mockFile] } })
+        fireEvent.click(importButton)
+      })
 
       // Should show loading state
       expect(screen.getByText(/importing/i)).toBeInTheDocument()

--- a/packages/presentation/web/src/components/__tests__/MiscInput.integration.test.tsx
+++ b/packages/presentation/web/src/components/__tests__/MiscInput.integration.test.tsx
@@ -67,24 +67,26 @@ describe('MiscInputIntegrated - CreateRecord Integration', () => {
       const promise = new Promise((resolve) => {
         resolvePromise = resolve
       })
-      
+
       ;(mockCreateRecordUseCase.execute as Mock).mockReturnValue(promise)
 
       const user = userEvent.setup()
       render(<MiscInputIntegrated />)
-      
+
       const input = screen.getByRole('textbox')
-      await user.type(input, 'tag1 tag2')
-      await user.keyboard('{Enter}')
+      await act(async () => {
+        await user.type(input, 'tag1 tag2')
+        await user.keyboard('{Enter}')
+      })
 
       // Check loading state
       await waitFor(() => {
         expect(screen.getByRole('textbox')).toBeDisabled()
         expect(screen.getByText(/creating/i)).toBeInTheDocument()
       })
-      
+
       // Resolve the promise
-      act(() => {
+      await act(async () => {
         resolvePromise!(Ok({ record: { id: 'test' } }))
       })
     })
@@ -305,10 +307,12 @@ describe('MiscInputIntegrated - SearchRecords Integration', () => {
 
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
       render(<MiscInputIntegrated />)
-      
+
       const input = screen.getByRole('textbox')
-      await user.type(input, 'test')
-      
+      await act(async () => {
+        await user.type(input, 'test')
+      })
+
       act(() => {
         vi.advanceTimersByTime(300)
       })
@@ -316,8 +320,8 @@ describe('MiscInputIntegrated - SearchRecords Integration', () => {
       await waitFor(() => {
         expect(screen.getByText(/searching/i)).toBeInTheDocument()
       })
-      
-      act(() => {
+
+      await act(async () => {
         resolvePromise!(Ok({ searchResult: { records: [], totalCount: 0, hasMore: false } }))
       })
     })

--- a/packages/presentation/web/src/hooks/__tests__/useRecordsIntegrated.test.ts
+++ b/packages/presentation/web/src/hooks/__tests__/useRecordsIntegrated.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, act } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach, Mock } from 'vitest'
 import { useRecordsIntegrated } from '../useRecordsIntegrated'
 import { useApplicationContext } from '../../contexts/ApplicationContext'
@@ -113,9 +113,12 @@ describe('useRecordsIntegrated', () => {
         expect(result.current.isLoading).toBe(false)
       })
 
-      const success = await result.current.createRecord(['new', 'tag'])
+      let success: boolean
+      await act(async () => {
+        success = await result.current.createRecord(['new', 'tag'])
+      })
 
-      expect(success).toBe(true)
+      expect(success!).toBe(true)
       expect(mockCreateRecordUseCase.execute).toHaveBeenCalledWith({
         content: 'new tag'
       })
@@ -141,9 +144,12 @@ describe('useRecordsIntegrated', () => {
         expect(result.current.isLoading).toBe(false)
       })
 
-      const success = await result.current.createRecord(['duplicate', 'tag'])
+      let success: boolean
+      await act(async () => {
+        success = await result.current.createRecord(['duplicate', 'tag'])
+      })
 
-      expect(success).toBe(false)
+      expect(success!).toBe(false)
     })
   })
 
@@ -185,9 +191,12 @@ describe('useRecordsIntegrated', () => {
         expect(result.current.records).toHaveLength(1)
       })
 
-      const success = await result.current.updateRecord('record-1', ['updated', 'tags'])
+      let success: boolean
+      await act(async () => {
+        success = await result.current.updateRecord('record-1', ['updated', 'tags'])
+      })
 
-      expect(success).toBe(true)
+      expect(success!).toBe(true)
       expect(mockUpdateRecordUseCase.execute).toHaveBeenCalledWith({
         id: 'record-1',
         content: 'updated tags'
@@ -232,9 +241,12 @@ describe('useRecordsIntegrated', () => {
         expect(result.current.records).toHaveLength(1)
       })
 
-      const success = await result.current.deleteRecord('record-1')
+      let success: boolean
+      await act(async () => {
+        success = await result.current.deleteRecord('record-1')
+      })
 
-      expect(success).toBe(true)
+      expect(success!).toBe(true)
       expect(mockDeleteRecordUseCase.execute).toHaveBeenCalledWith({
         id: 'record-1'
       })
@@ -279,7 +291,9 @@ describe('useRecordsIntegrated', () => {
       })
 
       // Test filtering
-      result.current.setSearchQuery('javascript')
+      act(() => {
+        result.current.setSearchQuery('javascript')
+      })
 
       await waitFor(() => {
         expect(result.current.filteredRecords).toHaveLength(1)


### PR DESCRIPTION
…te React act() warnings

This commit fixes two major issues:

## 1. Critical Transaction Bug in CreateRecordUseCase
- **Root Cause**: Tags were saved outside transactions, records inside transactions
- **Impact**: Records lost if transaction failed, leaving orphaned tags in localStorage
- **Fix**: Move all database operations inside UnitOfWork transaction scope
  - Use `this.unitOfWork.tags.save()` instead of `this.tagRepository.save()`
  - Use `this.unitOfWork.records.save()` instead of `this.recordRepository.save()`
- **Result**: Proper atomicity - either both tags AND records save, or nothing saves

## 2. React act() Warnings Elimination
- Wrap all async state updates in `act()` calls across test files:
  - MiscInput.integration.test.tsx: userEvent operations and promise resolution
  - ImportExport.test.tsx: file upload and import operations
  - useRecordsIntegrated.test.ts: record CRUD operations and search queries
- **Result**: Zero React act() warnings in test output

## Test Results
- ✅ End-to-end test now PASSES (was timing out)
- ✅ 100/103 tests passing (up from 99)
- ✅ Zero React act() warnings (down from 12+)
- ✅ Real browser data inconsistency bug resolved

## Files Modified
- CreateRecordUseCase: Fixed transaction boundary violation
- Test files: Added proper act() wrappers for async operations
- End-to-end test: Enhanced debugging and proper integration testing

This resolves the production bug where users experienced data loss during record creation.