### PR TITLE
fix: make docker-compose test cross-platform compatible

### DIFF
--- a/packages/backend/src/__tests__/docker-compose-test.test.ts
+++ b/packages/backend/src/__tests__/docker-compose-test.test.ts
@@ -184,8 +184,17 @@ describe('Docker Compose Test Configuration', () => {
     );
     expect(fs.existsSync(testSetupPath)).toBe(true);
 
-    // Check if script is executable
+    // Check if script is executable (cross-platform)
     const stats = fs.statSync(testSetupPath);
-    expect(stats.mode & parseInt('111', 8)).toBeTruthy(); // Check execute permissions
+
+    // On Windows, all files are considered executable if they exist
+    // On Unix systems, check actual execute permissions
+    if (process.platform === 'win32') {
+      // On Windows, just verify the file exists and has content
+      expect(stats.size).toBeGreaterThan(0);
+    } else {
+      // On Unix systems, check execute permissions
+      expect(stats.mode & parseInt('111', 8)).toBeTruthy();
+    }
   });
 });


### PR DESCRIPTION
- Fix file permission check in docker-compose-test.test.ts for Windows compatibility
- Use platform-specific permission validation (Windows vs Unix)
- Ensures tests pass on both WSL and Windows Git Bash environments