### PR TITLE
fix(ci): restore fast-test optimization pattern in lint-staged

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -24,17 +24,21 @@ export default {
       if (hasBackendFiles) commands.push('yarn workspace @misc-poc/backend typecheck');
       if (hasWebFiles) commands.push('yarn workspace @misc-poc/presentation-web typecheck');
 
+      // Use fast tests only (exclude [perf] tagged integration tests)
+      // Pattern excludes tests with [perf] in describe/it names
+      const testPattern = '--testNamePattern="^(?:(?!perf).)*$"';
+
       // Add timeout wrapper for test commands (5 minutes for packages with integration tests)
-      if (hasSharedFiles) commands.push('timeout 180 yarn workspace @misc-poc/shared test');
-      if (hasDomainFiles) commands.push('timeout 180 yarn workspace @misc-poc/domain test');
-      if (hasApplicationFiles) commands.push('timeout 180 yarn workspace @misc-poc/application test');
+      if (hasSharedFiles) commands.push(`timeout 180 yarn workspace @misc-poc/shared test ${testPattern}`);
+      if (hasDomainFiles) commands.push(`timeout 180 yarn workspace @misc-poc/domain test ${testPattern}`);
+      if (hasApplicationFiles) commands.push(`timeout 180 yarn workspace @misc-poc/application test ${testPattern}`);
       if (hasInfrastructureFiles) {
-        commands.push('timeout 180 yarn workspace @misc-poc/infrastructure-localstorage test');
+        commands.push(`timeout 180 yarn workspace @misc-poc/infrastructure-localstorage test ${testPattern}`);
         // PostgreSQL package has extensive integration tests that need more time
-        commands.push('timeout 300 yarn workspace @misc-poc/infrastructure-postgresql test');
+        commands.push(`timeout 300 yarn workspace @misc-poc/infrastructure-postgresql test ${testPattern}`);
       }
-      if (hasBackendFiles) commands.push('timeout 180 yarn workspace @misc-poc/backend test');
-      if (hasWebFiles) commands.push('timeout 180 yarn workspace @misc-poc/presentation-web test');
+      if (hasBackendFiles) commands.push(`timeout 180 yarn workspace @misc-poc/backend test ${testPattern}`);
+      if (hasWebFiles) commands.push(`timeout 180 yarn workspace @misc-poc/presentation-web test ${testPattern}`);
 
       return commands;
     }


### PR DESCRIPTION
Combine all improvements:
- Keep typecheck commands from main
- Add timeout wrappers for integration tests
- Restore testNamePattern to exclude [perf] tests for faster pre-commit hooks

This ensures pre-commit hooks run quickly by excluding performance tests while still providing adequate timeout for remaining integration tests.